### PR TITLE
Add support for Thaumcraft 6 planks

### DIFF
--- a/src/main/resources/assets/unlimitedchiselworks/ucwdefs/chisel/thaumcraft.json
+++ b/src/main/resources/assets/unlimitedchiselworks/ucwdefs/chisel/thaumcraft.json
@@ -1,0 +1,39 @@
+{
+  "modid": ["chisel", "thaumcraft"],
+  "blocks": [
+    {
+      "from": {
+        "block": "thaumcraft:plank_silverwood",
+        "iterate": [
+          "variant"
+        ]
+      },
+      "through": {
+        "block": "chisel:planks-oak",
+        "iterate": [
+          "variation"
+        ]
+      },
+      "based_upon": {
+        "state": "minecraft:planks#variant=oak"
+      }
+    },
+	{
+      "from": {
+        "block": "thaumcraft:plank_greatwood",
+        "iterate": [
+          "variant"
+        ]
+      },
+      "through": {
+        "block": "chisel:planks-oak",
+        "iterate": [
+          "variation"
+        ]
+      },
+      "based_upon": {
+        "state": "minecraft:planks#variant=oak"
+      }
+    }
+  ]
+}


### PR DESCRIPTION
You previously mentioned in #40 that you were hoping Chisel would re-add support for Thaumcraft 6 but until then I thought it might be worth including in UCW for those of us hoping to build with it. 